### PR TITLE
fix: lock cargo-contract version to 1.5.1

### DIFF
--- a/.devcontainer/scripts/swanky-setup.sh
+++ b/.devcontainer/scripts/swanky-setup.sh
@@ -19,7 +19,7 @@ rustup target add wasm32-unknown-unknown --toolchain nightly
 rustup default nightly
 
 cargo install cargo-dylint dylint-link
-cargo install --force --locked cargo-contract
+cargo install cargo-contract --force --version 1.5.1
 
 swanky_folder="/opt/swanky"
 


### PR DESCRIPTION
Until the node, templates and polkadotjs are updated to support ink!4 (https://github.com/AstarNetwork/swanky-cli/issues/109) , cargo-contract should be kept locked at compatible version (v1.5.1)