### PR TITLE
Chore/update swanky version

### DIFF
--- a/.devcontainer/scripts/swanky-setup.sh
+++ b/.devcontainer/scripts/swanky-setup.sh
@@ -36,4 +36,9 @@ fi
 
 sudo chown vscode /workspace
 
-npm i -g serve
+if ! npm list -g | grep -q "serve"; then
+  echo "serve is not installed globally, installing..."
+  npm install -g serve
+else
+  echo "serve is already installed globally"
+fi

--- a/.devcontainer/scripts/swanky-setup.sh
+++ b/.devcontainer/scripts/swanky-setup.sh
@@ -24,7 +24,7 @@ cargo install cargo-contract --force --version 2.0.1
 swanky_folder="/opt/swanky"
 
 if [ ! -d "$swanky_folder" ]; then
-  wget -O /tmp/swanky.tar.gz https://github.com/AstarNetwork/swanky-cli/releases/download/v2.0.0/swanky-v2.0.0-e891a87-linux-x64.tar.gz && sudo tar -xf /tmp/swanky.tar.gz -C /opt
+  wget -O /tmp/swanky.tar.gz https://github.com/AstarNetwork/swanky-cli/releases/download/v2.1.0/swanky-v2.1.0-0237720-linux-x64.tar.gz && sudo tar -xf /tmp/swanky.tar.gz -C /opt
 fi
 
 link_path="/usr/local/bin/swanky"

--- a/.devcontainer/scripts/swanky-setup.sh
+++ b/.devcontainer/scripts/swanky-setup.sh
@@ -19,7 +19,7 @@ rustup target add wasm32-unknown-unknown --toolchain nightly
 rustup default nightly
 
 cargo install cargo-dylint dylint-link
-cargo install cargo-contract --force --version 2.0.1
+cargo install cargo-contract --force --version 2.1.0
 
 swanky_folder="/opt/swanky"
 


### PR DESCRIPTION
- update  swanky-cli to 2.1.0
- update cargo-contract to 2.1.0
- add check before installing `npm serve`